### PR TITLE
Wrapper font enhancements

### DIFF
--- a/src/IMUI/IMUISetup.h
+++ b/src/IMUI/IMUISetup.h
@@ -18,16 +18,16 @@ public:
     String LogFilename;
     /// add TTF font from static in-memory data
     void AddFontFromMemory(void* ttf_data, int ttf_size, float font_height);
-	void AddFontFromMemory(void* ttf_data, int ttf_size, float font_height, ImFontConfig* config);
-	void AddFontFromMemory(void* ttf_data, int ttf_size, float font_height, ImFontConfig* config, const ImWchar* ranges, bool compressed);
+    void AddFontFromMemory(void* ttf_data, int ttf_size, float font_height, ImFontConfig* config);
+    void AddFontFromMemory(void* ttf_data, int ttf_size, float font_height, ImFontConfig* config, const ImWchar* ranges, bool compressed);
 
     struct fontDesc {
         void* ttf_data = nullptr;
         int ttf_size = 0;
         float font_height = 13;
-		const ImWchar* glyph_ranges;
-		ImFontConfig* font_config;
-		bool compressed = false;
+        const ImWchar* glyph_ranges;
+        ImFontConfig* font_config;
+        bool compressed = false;
 	};
     static const int MaxFonts = 4;
     int numFonts = 0;

--- a/src/IMUI/IMUISetup.h
+++ b/src/IMUI/IMUISetup.h
@@ -18,12 +18,17 @@ public:
     String LogFilename;
     /// add TTF font from static in-memory data
     void AddFontFromMemory(void* ttf_data, int ttf_size, float font_height);
+	void AddFontFromMemory(void* ttf_data, int ttf_size, float font_height, ImFontConfig* config);
+	void AddFontFromMemory(void* ttf_data, int ttf_size, float font_height, ImFontConfig* config, const ImWchar* ranges, bool compressed);
 
     struct fontDesc {
         void* ttf_data = nullptr;
         int ttf_size = 0;
         float font_height = 13;
-    };
+		const ImWchar* glyph_ranges;
+		ImFontConfig* font_config;
+		bool compressed = false;
+	};
     static const int MaxFonts = 4;
     int numFonts = 0;
     StaticArray<fontDesc, MaxFonts> fonts;
@@ -31,13 +36,29 @@ public:
 
 //------------------------------------------------------------------------------
 inline void
-IMUISetup::AddFontFromMemory(void* ttf_data, int ttf_size, float font_height) {
-    o_assert_dbg(ttf_data && (ttf_size > 0));
-    fontDesc desc;
-    desc.ttf_data = ttf_data;
-    desc.ttf_size = ttf_size;
-    desc.font_height = font_height;
-    this->fonts[this->numFonts++] = desc;
+IMUISetup::AddFontFromMemory(void* ttf_data, const int ttf_size, const float font_height) {
+	ImFontConfig config;
+	AddFontFromMemory(ttf_data, ttf_size, font_height, &config);
 }
+
+inline void
+IMUISetup::AddFontFromMemory(void* ttf_data, const int ttf_size, const float font_height, ImFontConfig* config) {
+	AddFontFromMemory(ttf_data, ttf_size, font_height, config, ImGui::GetIO().Fonts->GetGlyphRangesDefault(), false);
+}
+
+inline void
+IMUISetup::AddFontFromMemory(void* ttf_data, const int ttf_size, const float font_height, ImFontConfig* config, const ImWchar* ranges, bool compressed = false) {
+	o_assert_dbg(ttf_data && (ttf_size > 0));
+	fontDesc desc;
+	desc.ttf_data = ttf_data;
+	desc.ttf_size = ttf_size;
+	desc.font_height = font_height;
+	desc.glyph_ranges = ranges;
+	desc.font_config = config;
+	desc.compressed = compressed;
+
+	this->fonts[this->numFonts++] = desc;
+}
+
 
 } // namespace Oryol

--- a/src/IMUI/IMUISetup.h
+++ b/src/IMUI/IMUISetup.h
@@ -37,27 +37,27 @@ public:
 //------------------------------------------------------------------------------
 inline void
 IMUISetup::AddFontFromMemory(void* ttf_data, const int ttf_size, const float font_height) {
-	ImFontConfig config;
-	AddFontFromMemory(ttf_data, ttf_size, font_height, &config);
+    ImFontConfig config;
+    AddFontFromMemory(ttf_data, ttf_size, font_height, &config);
 }
 
 inline void
 IMUISetup::AddFontFromMemory(void* ttf_data, const int ttf_size, const float font_height, ImFontConfig* config) {
-	AddFontFromMemory(ttf_data, ttf_size, font_height, config, ImGui::GetIO().Fonts->GetGlyphRangesDefault(), false);
+    AddFontFromMemory(ttf_data, ttf_size, font_height, config, ImGui::GetIO().Fonts->GetGlyphRangesDefault(), false);
 }
 
 inline void
 IMUISetup::AddFontFromMemory(void* ttf_data, const int ttf_size, const float font_height, ImFontConfig* config, const ImWchar* ranges, bool compressed = false) {
-	o_assert_dbg(ttf_data && (ttf_size > 0));
-	fontDesc desc;
-	desc.ttf_data = ttf_data;
-	desc.ttf_size = ttf_size;
-	desc.font_height = font_height;
-	desc.glyph_ranges = ranges;
-	desc.font_config = config;
-	desc.compressed = compressed;
+    o_assert_dbg(ttf_data && (ttf_size > 0));
+    fontDesc desc;
+    desc.ttf_data = ttf_data;
+    desc.ttf_size = ttf_size;
+    desc.font_height = font_height;
+    desc.glyph_ranges = ranges;
+    desc.font_config = config;
+    desc.compressed = compressed;
 
-	this->fonts[this->numFonts++] = desc;
+    this->fonts[this->numFonts++] = desc;
 }
 
 

--- a/src/IMUI/imguiWrapper.cc
+++ b/src/IMUI/imguiWrapper.cc
@@ -123,10 +123,12 @@ imguiWrapper::setupFontTexture(const IMUISetup& setup) {
     for (int i = 0; i < setup.numFonts; i++) {
         const auto& desc = setup.fonts[i];
         desc.font_config->FontDataOwnedByAtlas = false;
-        if (desc.compressed)
+        if (desc.compressed) {
             this->fonts[i] = io.Fonts->AddFontFromMemoryCompressedTTF(desc.ttf_data, desc.ttf_size, desc.font_height, desc.font_config, desc.glyph_ranges);
-        else 
+        }
+        else {
             this->fonts[i] = io.Fonts->AddFontFromMemoryTTF(desc.ttf_data, desc.ttf_size, desc.font_height, desc.font_config, desc.glyph_ranges);
+        }
         o_assert_dbg(this->fonts[i]);
     }
 

--- a/src/IMUI/imguiWrapper.cc
+++ b/src/IMUI/imguiWrapper.cc
@@ -121,10 +121,12 @@ imguiWrapper::setupFontTexture(const IMUISetup& setup) {
 
     io.Fonts->AddFontDefault();
     for (int i = 0; i < setup.numFonts; i++) {
-        ImFontConfig fontConfig;
-        fontConfig.FontDataOwnedByAtlas = false;
         const auto& desc = setup.fonts[i];
-        this->fonts[i] = io.Fonts->AddFontFromMemoryTTF(desc.ttf_data, desc.ttf_size, desc.font_height, &fontConfig);
+		desc.font_config->FontDataOwnedByAtlas = false;
+		if (desc.compressed)
+			this->fonts[i] = io.Fonts->AddFontFromMemoryCompressedTTF(desc.ttf_data, desc.ttf_size, desc.font_height, desc.font_config, desc.glyph_ranges);
+		else 
+			this->fonts[i] = io.Fonts->AddFontFromMemoryTTF(desc.ttf_data, desc.ttf_size, desc.font_height, desc.font_config, desc.glyph_ranges);
         o_assert_dbg(this->fonts[i]);
     }
 

--- a/src/IMUI/imguiWrapper.cc
+++ b/src/IMUI/imguiWrapper.cc
@@ -122,11 +122,11 @@ imguiWrapper::setupFontTexture(const IMUISetup& setup) {
     io.Fonts->AddFontDefault();
     for (int i = 0; i < setup.numFonts; i++) {
         const auto& desc = setup.fonts[i];
-		desc.font_config->FontDataOwnedByAtlas = false;
-		if (desc.compressed)
-			this->fonts[i] = io.Fonts->AddFontFromMemoryCompressedTTF(desc.ttf_data, desc.ttf_size, desc.font_height, desc.font_config, desc.glyph_ranges);
-		else 
-			this->fonts[i] = io.Fonts->AddFontFromMemoryTTF(desc.ttf_data, desc.ttf_size, desc.font_height, desc.font_config, desc.glyph_ranges);
+        desc.font_config->FontDataOwnedByAtlas = false;
+        if (desc.compressed)
+            this->fonts[i] = io.Fonts->AddFontFromMemoryCompressedTTF(desc.ttf_data, desc.ttf_size, desc.font_height, desc.font_config, desc.glyph_ranges);
+        else 
+            this->fonts[i] = io.Fonts->AddFontFromMemoryTTF(desc.ttf_data, desc.ttf_size, desc.font_height, desc.font_config, desc.glyph_ranges);
         o_assert_dbg(this->fonts[i]);
     }
 


### PR DESCRIPTION
`IMUISetup::AddFontFromMemory` now can optionally pass a font config, glyph ranges, and a flag indicating the font data is compressed (using [binary_to_compressed_c.cpp](https://github.com/ocornut/imgui/blob/master/misc/fonts/binary_to_compressed_c.cpp)).